### PR TITLE
FastLoad to 1.19.3 

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -2,15 +2,15 @@
 org.gradle.jvmargs=-Xmx1G
 
 # Fabric Properties
-	minecraft_version=1.19.2
-	yarn_mappings=1.19.2+build.28
+	minecraft_version=1.19.3-pre2
+	yarn_mappings=1.19.3-pre2+build.4
 	loader_version=0.14.10
 
 	fabric_resource_loader_version=0.8.1+0d0f210290
 
-	modmenu_version=4.1.1
+	modmenu_version=5.0.0-alpha.4
 
 # Mod Properties
 	mod_version = 2.4.2
 	maven_group = io.github.bumblesoftware.fastload
-	archives_base_name = Fastload+1.19.2
+	archives_base_name = Fastload+1.19.3

--- a/src/main/java/io/github/bumblesoftware/fastload/config/screen/FLButtonWidget.java
+++ b/src/main/java/io/github/bumblesoftware/fastload/config/screen/FLButtonWidget.java
@@ -1,0 +1,10 @@
+package io.github.bumblesoftware.fastload.config.screen;
+
+import net.minecraft.client.gui.widget.ButtonWidget;
+import net.minecraft.text.Text;
+
+public class FLButtonWidget extends ButtonWidget {
+    public FLButtonWidget(int x, int y, int width, int height, Text message, PressAction onPress) {
+        super(x, y, width, height, message, onPress, ButtonWidget.DEFAULT_NARRATION_SUPPLIER);
+    }
+}

--- a/src/main/java/io/github/bumblesoftware/fastload/config/screen/FLConfigScreen.java
+++ b/src/main/java/io/github/bumblesoftware/fastload/config/screen/FLConfigScreen.java
@@ -7,7 +7,6 @@ import io.github.bumblesoftware.fastload.init.FastLoad;
 import net.minecraft.client.MinecraftClient;
 import net.minecraft.client.gui.screen.Screen;
 import net.minecraft.client.gui.screen.option.SimpleOptionsScreen;
-import net.minecraft.client.gui.widget.ButtonWidget;
 import net.minecraft.client.option.SimpleOption;
 import net.minecraft.client.util.math.MatrixStack;
 import net.minecraft.screen.ScreenTexts;
@@ -31,7 +30,7 @@ public class FLConfigScreen extends SimpleOptionsScreen {
 
     @Override
     protected void initFooter() {
-        this.addDrawableChild(new ButtonWidget(this.width / 2 - 100, this.height - 27, 200, 20, ScreenTexts.DONE, button -> {
+        this.addDrawableChild(new FLButtonWidget(this.width / 2 - 100, this.height - 27, 200, 20, ScreenTexts.DONE, button -> {
             /**
              * When the button "Done" is pressed, this for loop simply iterates through the values stored in memory,
              * the addresses to the config & writes it.

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -35,7 +35,7 @@
   "accessWidener": "fastload.accesswidener",
   "depends": {
     "fabricloader": ">=0.14.10",
-    "minecraft": "~1.19.2",
+    "minecraft": ">=1.19.2",
     "java": ">=17"
   },
   "breaks": {

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -35,7 +35,7 @@
   "accessWidener": "fastload.accesswidener",
   "depends": {
     "fabricloader": ">=0.14.10",
-    "minecraft": ">=1.19.2",
+    "minecraft": ">=1.19.3-beta.2",
     "java": ">=17"
   },
   "breaks": {


### PR DESCRIPTION
# Fastload to 1.19.3

Changelogs: 

- Updated to support 1.19.3
- Fixed some small issues to make FL operate fully on 1.19.3

If all goes well, this will be merged later on the 8th of december with the release of 1.19.3. 